### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gdglatrobe/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gdglatrobe/Engineering
+* @gdglatrobe/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gdglatrobe/engineering
+* @gdglatrobe/Engineering


### PR DESCRIPTION
This enforces that PRs can only be approved for merge by people in the "Engineering" GitHub team.